### PR TITLE
feat: add EDA notebook

### DIFF
--- a/notebooks/02 EDA.ipynb
+++ b/notebooks/02 EDA.ipynb
@@ -18,7 +18,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371537424
+     "logged": 1650383626690
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -49,7 +49,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371541832
+     "logged": 1650383630758
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -64,7 +64,7 @@
    "outputs": [],
    "source": [
     "# Load into pandas\n",
-    "df = pd.read_parquet(\"../data/original-data.parquet\")"
+    "original_data_df = pd.read_parquet(\"../data/original-data.parquet\")"
    ]
   },
   {
@@ -85,7 +85,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371542108
+     "logged": 1650383631032
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -99,7 +99,7 @@
    },
    "outputs": [],
    "source": [
-    "df.dtypes"
+    "original_data_df.dtypes"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371542392
+     "logged": 1650383631301
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -121,7 +121,7 @@
    },
    "outputs": [],
    "source": [
-    "df.arrival_day_of_week.unique()"
+    "original_data_df.arrival_day_of_week.unique()"
    ]
   },
   {
@@ -129,7 +129,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371542621
+     "logged": 1650383631522
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -143,7 +143,7 @@
    },
    "outputs": [],
    "source": [
-    "df.arrival_month_name.unique()"
+    "original_data_df.arrival_month_name.unique()"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371542835
+     "logged": 1650383631758
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -178,7 +178,7 @@
    },
    "outputs": [],
    "source": [
-    "df2 = df.copy()"
+    "datetimes_df = original_data_df.copy()"
    ]
   },
   {
@@ -186,7 +186,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371543039
+     "logged": 1650383632020
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -200,8 +200,8 @@
    },
    "outputs": [],
    "source": [
-    "df2.DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL = pd.to_datetime(\n",
-    "    df2.DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
+    "datetimes_df.DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL = pd.to_datetime(\n",
+    "    datetimes_df.DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
     ")"
    ]
   },
@@ -210,7 +210,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371543248
+     "logged": 1650383632245
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -226,8 +226,8 @@
    "source": [
     "# mainly nan\n",
     "# df2.DISCHARGE_READY_DATE.sample(10)\n",
-    "df2.EXPECTED_DISCHARGE_DATE = pd.to_datetime(\n",
-    "    df2.EXPECTED_DISCHARGE_DATE, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
+    "datetimes_df.EXPECTED_DISCHARGE_DATE = pd.to_datetime(\n",
+    "    datetimes_df.EXPECTED_DISCHARGE_DATE, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
     ")"
    ]
   },
@@ -236,7 +236,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371543676
+     "logged": 1650383632648
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -250,8 +250,8 @@
    },
    "outputs": [],
    "source": [
-    "df2.FIRST_START_DATE_TIME_WARD_STAY = pd.to_datetime(\n",
-    "    df2.FIRST_START_DATE_TIME_WARD_STAY, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
+    "datetimes_df.FIRST_START_DATE_TIME_WARD_STAY = pd.to_datetime(\n",
+    "    datetimes_df.FIRST_START_DATE_TIME_WARD_STAY, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
     ")"
    ]
   },
@@ -260,7 +260,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371544077
+     "logged": 1650383632941
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -274,8 +274,8 @@
    },
    "outputs": [],
    "source": [
-    "df2.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL = pd.to_datetime(\n",
-    "    df2.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
+    "datetimes_df.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL = pd.to_datetime(\n",
+    "    datetimes_df.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
     ")"
    ]
   },
@@ -284,7 +284,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371544327
+     "logged": 1650383633167
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -298,7 +298,7 @@
    },
    "outputs": [],
    "source": [
-    "df2.dtypes"
+    "datetimes_df.dtypes"
    ]
   },
   {
@@ -315,13 +315,13 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371544536
+     "logged": 1650383633399
     }
    },
    "outputs": [],
    "source": [
     "# check data types before conducting maths\n",
-    "df2[\n",
+    "datetimes_df[\n",
     "    [\n",
     "        \"DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL\",\n",
     "        \"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\",\n",
@@ -334,13 +334,13 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371544739
+     "logged": 1650383633663
     }
    },
    "outputs": [],
    "source": [
     "# Discharge is whole day, admission is datetime\n",
-    "df2[\n",
+    "datetimes_df[\n",
     "    [\n",
     "        \"DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL\",\n",
     "        \"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\",\n",
@@ -353,16 +353,16 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371544954
+     "logged": 1650383633877
     }
    },
    "outputs": [],
    "source": [
     "# calculate derived LoS\n",
     "# round up to whole days\n",
-    "df2[\"DER_los\"] = (\n",
-    "    df2[\"DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL\"]\n",
-    "    - df2[\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\"]\n",
+    "datetimes_df[\"DER_los\"] = (\n",
+    "    datetimes_df[\"DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL\"]\n",
+    "    - datetimes_df[\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\"]\n",
     ").dt.days + 1"
    ]
   },
@@ -371,13 +371,13 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371545163
+     "logged": 1650383634149
     }
    },
    "outputs": [],
    "source": [
     "# quick visual inspection - do they match?\n",
-    "df2[[\"DER_los\", \"LENGTH_OF_STAY\"]].head(10)"
+    "datetimes_df[[\"DER_los\", \"LENGTH_OF_STAY\"]].head(10)"
    ]
   },
   {
@@ -385,13 +385,13 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371545367
+     "logged": 1650383634374
     }
    },
    "outputs": [],
    "source": [
     "# check that mean difference is ~ 0 days\n",
-    "df2[[\"DER_los\", \"LENGTH_OF_STAY\"]].diff(axis=1).LENGTH_OF_STAY.mean()"
+    "datetimes_df[[\"DER_los\", \"LENGTH_OF_STAY\"]].diff(axis=1).LENGTH_OF_STAY.mean()"
    ]
   },
   {
@@ -399,13 +399,13 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371545563
+     "logged": 1650383634587
     }
    },
    "outputs": [],
    "source": [
     "# drop the derived column\n",
-    "df2.drop(columns=\"DER_los\", inplace=True)"
+    "datetimes_df.drop(columns=\"DER_los\", inplace=True)"
    ]
   },
   {
@@ -428,7 +428,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371545772
+     "logged": 1650383634811
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -443,7 +443,7 @@
    "outputs": [],
    "source": [
     "# not ordered by local patient id\n",
-    "df2.LOCAL_PATIENT_IDENTIFIER.head(10)\n",
+    "datetimes_df.LOCAL_PATIENT_IDENTIFIER.head(10)\n",
     "\n",
     "# nb. value_counts() shows repeat visits - could this be feature?"
    ]
@@ -453,7 +453,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371545979
+     "logged": 1650383635034
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -468,7 +468,7 @@
    "outputs": [],
    "source": [
     "# not ordered by start-date\n",
-    "df2.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL.head(10)"
+    "datetimes_df.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL.head(10)"
    ]
   },
   {
@@ -476,7 +476,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371546194
+     "logged": 1650383635289
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -491,7 +491,7 @@
    "outputs": [],
    "source": [
     "# not by end-date\n",
-    "df2.DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL.head(10)"
+    "datetimes_df.DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL.head(10)"
    ]
   },
   {
@@ -499,7 +499,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371546432
+     "logged": 1650383635510
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -514,7 +514,7 @@
    "outputs": [],
    "source": [
     "# not by cds\n",
-    "df2.cds_unique_identifier.sample(10)"
+    "datetimes_df.cds_unique_identifier.sample(10)"
    ]
   },
   {
@@ -535,7 +535,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371546732
+     "logged": 1650383727260
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -549,9 +549,9 @@
    },
    "outputs": [],
    "source": [
-    "df3 = df2.sort_values(by=\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\").reset_index(\n",
-    "    drop=True\n",
-    ")"
+    "sorted_datetimes_df = datetimes_df.sort_values(\n",
+    "    by=\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\"\n",
+    ").reset_index(drop=True)"
    ]
   },
   {
@@ -559,7 +559,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371546943
+     "logged": 1650383728959
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -573,7 +573,7 @@
    },
    "outputs": [],
    "source": [
-    "df3.head(10)"
+    "sorted_datetimes_df.head(10)"
    ]
   },
   {
@@ -594,7 +594,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371625989
+     "logged": 1650383810724
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -609,7 +609,7 @@
    "outputs": [],
    "source": [
     "sns.set(rc={\"figure.figsize\": (15, 8)})\n",
-    "sns.heatmap(df3.isnull(), cbar=False);"
+    "sns.heatmap(sorted_datetimes_df.isnull(), cbar=False);"
    ]
   },
   {
@@ -617,7 +617,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371627651
+     "logged": 1650383811953
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -631,7 +631,7 @@
    },
    "outputs": [],
    "source": [
-    "df3.isnull().sum()"
+    "sorted_datetimes_df.isnull().sum()"
    ]
   },
   {
@@ -639,7 +639,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371627928
+     "logged": 1650383812470
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -653,7 +653,7 @@
    },
    "outputs": [],
    "source": [
-    "df3.IS_major.unique()"
+    "sorted_datetimes_df.IS_major.unique()"
    ]
   },
   {
@@ -661,7 +661,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371628179
+     "logged": 1650383812854
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -675,7 +675,7 @@
    },
    "outputs": [],
    "source": [
-    "df3.IS_major.value_counts()"
+    "sorted_datetimes_df.IS_major.value_counts()"
    ]
   },
   {
@@ -683,7 +683,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371629116
+     "logged": 1650383856665
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -698,7 +698,7 @@
    "outputs": [],
    "source": [
     "# Extract columns with 100% empty values\n",
-    "empty_cols = df3.isnull().sum() == df.shape[0]\n",
+    "empty_cols = sorted_datetimes_df.isnull().sum() == sorted_datetimes_df.shape[0]\n",
     "empty_cols = empty_cols[empty_cols].index.array"
    ]
   },
@@ -707,7 +707,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371629347
+     "logged": 1650383864082
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -722,7 +722,7 @@
    "outputs": [],
    "source": [
     "for col in empty_cols:\n",
-    "    print(f\"{col} values: {df[col].unique()}\")"
+    "    print(f\"{col} values: {sorted_datetimes_df[col].unique()}\")"
    ]
   },
   {
@@ -730,7 +730,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371629681
+     "logged": 1650383877149
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -744,7 +744,8 @@
    },
    "outputs": [],
    "source": [
-    "df4 = df3.drop(columns=empty_cols)"
+    "# df_remove_empty_cols\n",
+    "remove_empty_cols_df = sorted_datetimes_df.drop(columns=empty_cols)"
    ]
   },
   {
@@ -752,7 +753,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371629896
+     "logged": 1650383878041
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -766,7 +767,7 @@
    },
    "outputs": [],
    "source": [
-    "df4[df4.stroke_ward_stay.notna()].shape"
+    "remove_empty_cols_df[remove_empty_cols_df.stroke_ward_stay.notna()].shape"
    ]
   },
   {
@@ -774,7 +775,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371630139
+     "logged": 1650383878750
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -788,7 +789,7 @@
    },
    "outputs": [],
    "source": [
-    "df4.stroke_ward_stay.value_counts()"
+    "remove_empty_cols_df.stroke_ward_stay.value_counts()"
    ]
   },
   {
@@ -801,9 +802,11 @@
     }
    },
    "source": [
-    "Question:\n",
+    "## Identify early block of missing data\n",
     "\n",
-    "1. When does the block of missing data end?\n"
+    "The first ~100k rows are missing a significant amount of data - is this due to the introduction of a new system?\n",
+    "\n",
+    "1. When does the block of missing data end? Does this align with a new clinical system?\n"
    ]
   },
   {
@@ -811,7 +814,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371630373
+     "logged": 1650383897155
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -825,9 +828,10 @@
    },
    "outputs": [],
    "source": [
-    "df4.iloc[df4.presenting_complaint.first_valid_index()][\n",
-    "    [\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\", \"presenting_complaint\"]\n",
-    "]"
+    "# find the first valid index (ie. not null) for the presenting_complaint field, one of the frequently null fields\n",
+    "remove_empty_cols_df.iloc[\n",
+    "    remove_empty_cols_df.presenting_complaint.first_valid_index()\n",
+    "][[\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\", \"presenting_complaint\"]]"
    ]
   },
   {
@@ -835,7 +839,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371630599
+     "logged": 1650383913164
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -849,9 +853,10 @@
    },
    "outputs": [],
    "source": [
-    "df4.iloc[df4.presenting_complaint.first_valid_index() - 1][\n",
-    "    [\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\", \"presenting_complaint\"]\n",
-    "]"
+    "# check the previous entry to confirm it has a missing \"presenting complaint\"\n",
+    "remove_empty_cols_df.iloc[\n",
+    "    remove_empty_cols_df.presenting_complaint.first_valid_index() - 1\n",
+    "][[\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\", \"presenting_complaint\"]]"
    ]
   },
   {
@@ -872,7 +877,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371631614
+     "logged": 1650383929706
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -887,7 +892,7 @@
    "outputs": [],
    "source": [
     "# Pearson correlation by default:\n",
-    "corr = df4.corr()"
+    "corr = remove_empty_cols_df.corr()"
    ]
   },
   {
@@ -895,7 +900,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371632729
+     "logged": 1650383930713
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -939,7 +944,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371632951
+     "logged": 1650383931008
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -953,8 +958,8 @@
    },
    "outputs": [],
    "source": [
-    "print(df4.FIRST_WARD_STAY_IDENTIFIER.unique())\n",
-    "df4.FIRST_WARD_STAY_IDENTIFIER.value_counts()"
+    "print(remove_empty_cols_df.FIRST_WARD_STAY_IDENTIFIER.unique())\n",
+    "remove_empty_cols_df.FIRST_WARD_STAY_IDENTIFIER.value_counts()"
    ]
   },
   {
@@ -962,7 +967,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371633157
+     "logged": 1650383931196
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -977,7 +982,7 @@
    "outputs": [],
    "source": [
     "# Remove empty/single value columns\n",
-    "df5 = df4.drop(\n",
+    "remove_low_cardinality_df = remove_empty_cols_df.drop(\n",
     "    columns=[\n",
     "        \"FIRST_WARD_STAY_IDENTIFIER\",\n",
     "        \"LENGTH_OF_STAY_IN_MINUTES\",\n",
@@ -992,7 +997,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371633382
+     "logged": 1650383931474
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1007,7 +1012,7 @@
    "outputs": [],
    "source": [
     "# How many negative/invalid LoS are there?\n",
-    "df5[df5.LENGTH_OF_STAY < 0].shape"
+    "remove_low_cardinality_df[remove_low_cardinality_df.LENGTH_OF_STAY < 0].shape"
    ]
   },
   {
@@ -1015,7 +1020,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371633616
+     "logged": 1650383931897
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1029,8 +1034,9 @@
    },
    "outputs": [],
    "source": [
+    "# df_valid_los\n",
     "# Remove invalid LoS\n",
-    "df6 = df5[df5.LENGTH_OF_STAY > -1]"
+    "valid_los_df = remove_low_cardinality_df[remove_low_cardinality_df.LENGTH_OF_STAY > -1]"
    ]
   },
   {
@@ -1051,7 +1057,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371637953
+     "logged": 1650383936186
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1065,7 +1071,7 @@
    },
    "outputs": [],
    "source": [
-    "df6[df6.duplicated(keep=False)].sort_values(\n",
+    "valid_los_df[valid_los_df.duplicated(keep=False)].sort_values(\n",
     "    by=\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\"\n",
     ").head()"
    ]
@@ -1075,7 +1081,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371642620
+     "logged": 1650383940835
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1089,7 +1095,8 @@
    },
    "outputs": [],
    "source": [
-    "df7 = df6.drop_duplicates()"
+    "# df_no_duplicates\n",
+    "no_duplicate_rows_df = valid_los_df.drop_duplicates()"
    ]
   },
   {
@@ -1097,7 +1104,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371642874
+     "logged": 1650383941018
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1111,8 +1118,7 @@
    },
    "outputs": [],
    "source": [
-    "print(df6.shape)\n",
-    "print(df7.shape)"
+    "print(no_duplicate_rows_df.shape)"
    ]
   },
   {
@@ -1133,7 +1139,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371643135
+     "logged": 1650383941306
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1147,7 +1153,10 @@
    },
    "outputs": [],
    "source": [
-    "df7.FIRST_START_DATE_TIME_WARD_STAY.equals(df7.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL)"
+    "# check if FIRST_START_DATE_TIME_WARD_STAY is the same as START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\n",
+    "no_duplicate_rows_df.FIRST_START_DATE_TIME_WARD_STAY.equals(\n",
+    "    no_duplicate_rows_df.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\n",
+    ")"
    ]
   },
   {
@@ -1155,7 +1164,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371643369
+     "logged": 1650383941531
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1169,9 +1178,10 @@
    },
    "outputs": [],
    "source": [
-    "df7[\n",
+    "# they are different, so work out what the difference is between the columns\n",
+    "no_duplicate_rows_df[\n",
     "    [\"FIRST_START_DATE_TIME_WARD_STAY\", \"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\"]\n",
-    "].sample(100).diff(axis=1)"
+    "].sample(10).diff(axis=1)"
    ]
   },
   {
@@ -1179,7 +1189,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371643587
+     "logged": 1650383941736
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1193,30 +1203,12 @@
    },
    "outputs": [],
    "source": [
-    "df7.loc[154218]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "gather": {
-     "logged": 1650371643921
-    },
-    "jupyter": {
-     "outputs_hidden": false,
-     "source_hidden": false
-    },
-    "nteract": {
-     "transient": {
-      "deleting": false
-     }
-    }
-   },
-   "outputs": [],
-   "source": [
+    "# there are many NaT values in FIRST_START_DATE_TIME_WARD_STAY which lead to a difference of 0 days\n",
+    "# find out if there are any actual differences in dates\n",
     "(\n",
-    "    df7[[\"FIRST_START_DATE_TIME_WARD_STAY\", \"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\"]]\n",
+    "    no_duplicate_rows_df[\n",
+    "        [\"FIRST_START_DATE_TIME_WARD_STAY\", \"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\"]\n",
+    "    ]\n",
     "    .diff(axis=1)\n",
     "    .START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\n",
     "    > pd.Timedelta(0)\n",
@@ -1228,7 +1220,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371644204
+     "logged": 1650383942025
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1242,8 +1234,11 @@
    },
    "outputs": [],
    "source": [
-    "# Drop duplicate columns\n",
-    "df8 = df7.drop(columns=\"FIRST_START_DATE_TIME_WARD_STAY\")"
+    "# There are very few differences in dates given the sparsity of the FIRST_START_DATE_TIME_WARD_STAY\n",
+    "# so drop this column\n",
+    "no_duplicate_cols_df = no_duplicate_rows_df.drop(\n",
+    "    columns=\"FIRST_START_DATE_TIME_WARD_STAY\"\n",
+    ")"
    ]
   },
   {
@@ -1251,7 +1246,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371644418
+     "logged": 1650383942394
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1265,7 +1260,7 @@
    },
    "outputs": [],
    "source": [
-    "df8.shape"
+    "no_duplicate_cols_df.shape"
    ]
   },
   {
@@ -1286,7 +1281,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371644677
+     "logged": 1650383942718
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1310,7 +1305,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371644883
+     "logged": 1650383942909
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1325,7 +1320,9 @@
    "outputs": [],
    "source": [
     "# Dataset large and crashing without minimal=True\n",
-    "profile = ProfileReport(df8, title=\"Pandas Profiling Report\", minimal=True)"
+    "profile = ProfileReport(\n",
+    "    no_duplicate_cols_df, title=\"Pandas Profiling Report\", minimal=True\n",
+    ")"
    ]
   },
   {
@@ -1333,7 +1330,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371692609
+     "logged": 1650383994203
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1355,7 +1352,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371692813
+     "logged": 1650383994420
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1369,7 +1366,7 @@
    },
    "outputs": [],
    "source": [
-    "df8.attendance_type.value_counts()"
+    "no_duplicate_cols_df.attendance_type.value_counts()"
    ]
   },
   {
@@ -1377,7 +1374,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371693068
+     "logged": 1650383994779
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1392,7 +1389,7 @@
    "outputs": [],
    "source": [
     "# Drop invalid/incomplete columns\n",
-    "df9 = df8.drop(\n",
+    "no_incomplete_cols_df = no_duplicate_cols_df.drop(\n",
     "    columns=[\n",
     "        \"FIRST_REGULAR_DAY_OR_NIGHT_ADMISSION_DESCRIPTION\",\n",
     "        \"wait\",\n",
@@ -1409,7 +1406,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371760067
+     "logged": 1650384060246
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1424,7 +1421,7 @@
    "outputs": [],
    "source": [
     "sns.set(rc={\"figure.figsize\": (15, 8)})\n",
-    "sns.heatmap(df9.isnull(), cbar=False);"
+    "sns.heatmap(no_incomplete_cols_df.isnull(), cbar=False);"
    ]
   },
   {
@@ -1445,7 +1442,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371764873
+     "logged": 1650384065181
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1459,7 +1456,7 @@
    },
    "outputs": [],
    "source": [
-    "df9.to_parquet(\"../data/02-eda.parquet\")"
+    "no_incomplete_cols_df.to_parquet(\"../data/02-eda.parquet\")"
    ]
   },
   {
@@ -1476,14 +1473,14 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650371765677
+     "logged": 1650384065912
     }
    },
    "outputs": [],
    "source": [
     "# Export cols/descriptions for Excel/Google Sheets import\n",
-    "df9.dtypes.to_csv(\"../data/cols.csv\")\n",
-    "df9.describe().to_csv(\"../data/describe.csv\")"
+    "no_incomplete_cols_df.dtypes.to_csv(\"../data/cols.csv\")\n",
+    "no_incomplete_cols_df.describe().to_csv(\"../data/describe.csv\")"
    ]
   }
  ],

--- a/notebooks/02 EDA.ipynb
+++ b/notebooks/02 EDA.ipynb
@@ -828,6 +828,7 @@
    },
    "outputs": [],
    "source": [
+    "# the data has been ordered by admission date, so we can check for first index where missing data ends:\n",
     "# find the first valid index (ie. not null) for the presenting_complaint field, one of the frequently null fields\n",
     "remove_empty_cols_df.iloc[\n",
     "    remove_empty_cols_df.presenting_complaint.first_valid_index()\n",

--- a/notebooks/02 EDA.ipynb
+++ b/notebooks/02 EDA.ipynb
@@ -18,7 +18,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364588365
+     "logged": 1650371537424
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -49,7 +49,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364598222
+     "logged": 1650371541832
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -85,7 +85,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364632781
+     "logged": 1650371542108
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -107,7 +107,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364636444
+     "logged": 1650371542392
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -129,7 +129,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364637136
+     "logged": 1650371542621
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -164,7 +164,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364646009
+     "logged": 1650371542835
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -186,7 +186,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364646630
+     "logged": 1650371543039
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -210,7 +210,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364648635
+     "logged": 1650371543248
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -236,7 +236,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364649728
+     "logged": 1650371543676
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -260,7 +260,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364651621
+     "logged": 1650371544077
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -284,7 +284,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364659732
+     "logged": 1650371544327
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -299,6 +299,113 @@
    "outputs": [],
    "source": [
     "df2.dtypes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sanity checks\n",
+    "\n",
+    "Does the LENGTH_OF_STAY match start/end dates?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650371544536
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# check data types before conducting maths\n",
+    "df2[\n",
+    "    [\n",
+    "        \"DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL\",\n",
+    "        \"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\",\n",
+    "    ]\n",
+    "].dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650371544739
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Discharge is whole day, admission is datetime\n",
+    "df2[\n",
+    "    [\n",
+    "        \"DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL\",\n",
+    "        \"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\",\n",
+    "    ]\n",
+    "].sample(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650371544954
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# calculate derived LoS\n",
+    "# round up to whole days\n",
+    "df2[\"DER_los\"] = (\n",
+    "    df2[\"DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL\"]\n",
+    "    - df2[\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\"]\n",
+    ").dt.days + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650371545163
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# quick visual inspection - do they match?\n",
+    "df2[[\"DER_los\", \"LENGTH_OF_STAY\"]].head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650371545367
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# check that mean difference is ~ 0 days\n",
+    "df2[[\"DER_los\", \"LENGTH_OF_STAY\"]].diff(axis=1).LENGTH_OF_STAY.mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650371545563
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# drop the derived column\n",
+    "df2.drop(columns=\"DER_los\", inplace=True)"
    ]
   },
   {
@@ -321,7 +428,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364674378
+     "logged": 1650371545772
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -346,7 +453,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364699219
+     "logged": 1650371545979
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -369,7 +476,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364703141
+     "logged": 1650371546194
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -392,7 +499,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364706155
+     "logged": 1650371546432
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -428,7 +535,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364712638
+     "logged": 1650371546732
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -452,7 +559,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364712896
+     "logged": 1650371546943
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -487,7 +594,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364793792
+     "logged": 1650371625989
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -510,7 +617,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364811686
+     "logged": 1650371627651
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -532,7 +639,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364811990
+     "logged": 1650371627928
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -554,7 +661,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364812191
+     "logged": 1650371628179
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -576,7 +683,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364814773
+     "logged": 1650371629116
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -600,7 +707,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364818187
+     "logged": 1650371629347
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -623,7 +730,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364821732
+     "logged": 1650371629681
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -645,7 +752,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364822763
+     "logged": 1650371629896
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -667,7 +774,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364823900
+     "logged": 1650371630139
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -704,7 +811,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364827198
+     "logged": 1650371630373
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -728,7 +835,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364828194
+     "logged": 1650371630599
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -765,7 +872,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364836652
+     "logged": 1650371631614
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -788,7 +895,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364837702
+     "logged": 1650371632729
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -832,7 +939,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364849249
+     "logged": 1650371632951
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -855,7 +962,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364869643
+     "logged": 1650371633157
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -885,7 +992,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364886392
+     "logged": 1650371633382
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -908,7 +1015,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364892662
+     "logged": 1650371633616
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -944,7 +1051,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364898062
+     "logged": 1650371637953
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -968,7 +1075,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364902644
+     "logged": 1650371642620
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -990,7 +1097,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364902916
+     "logged": 1650371642874
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1026,7 +1133,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364903100
+     "logged": 1650371643135
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1048,7 +1155,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364903316
+     "logged": 1650371643369
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1072,7 +1179,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364903576
+     "logged": 1650371643587
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1094,7 +1201,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364904756
+     "logged": 1650371643921
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1121,7 +1228,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364921884
+     "logged": 1650371644204
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1144,7 +1251,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364922064
+     "logged": 1650371644418
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1179,7 +1286,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364923945
+     "logged": 1650371644677
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1203,7 +1310,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364933610
+     "logged": 1650371644883
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1226,7 +1333,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364983208
+     "logged": 1650371692609
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1248,7 +1355,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1646758800346
+     "logged": 1650371692813
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1270,7 +1377,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650364983494
+     "logged": 1650371693068
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1302,7 +1409,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650365048840
+     "logged": 1650371760067
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1338,7 +1445,7 @@
    "execution_count": null,
    "metadata": {
     "gather": {
-     "logged": 1650365053678
+     "logged": 1650371764873
     },
     "jupyter": {
      "outputs_hidden": false,
@@ -1354,6 +1461,30 @@
    "source": [
     "df9.to_parquet(\"../data/02-eda.parquet\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export data dictionary fields\n",
+    "\n",
+    "Data dictionary will be created in Google Sheets/Excel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650371765677
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Export cols/descriptions for Excel/Google Sheets import\n",
+    "df9.dtypes.to_csv(\"../data/cols.csv\")\n",
+    "df9.describe().to_csv(\"../data/describe.csv\")"
+   ]
   }
  ],
  "metadata": {
@@ -1361,7 +1492,7 @@
    "hash": "6d65a8c07f5b6469e0fc613f182488c0dccce05038bbda39e5ac9075c0454d11"
   },
   "kernel_info": {
-   "name": "python3"
+   "name": "python38-azureml"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/02 EDA.ipynb
+++ b/notebooks/02 EDA.ipynb
@@ -1,0 +1,1391 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 02 Exploratory Data Analysis\n",
+    "\n",
+    "Notebook goal: initial Exploratory Data Analysis to understand features, data cleanliness and basic (inter)correlations.\n",
+    "\n",
+    "## 1. Load data\n",
+    "\n",
+    "Data processed in previous notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364588365
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pandas_profiling import ProfileReport\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import seaborn as sns\n",
+    "\n",
+    "%matplotlib inline\n",
+    "\n",
+    "pd.set_option(\"display.max_columns\", None)\n",
+    "pd.set_option(\"display.max_rows\", None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364598222
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Load into pandas\n",
+    "df = pd.read_parquet(\"../data/original-data.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "## Explore Data types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364632781
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364636444
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df.arrival_day_of_week.unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364637136
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df.arrival_month_name.unique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "## Convert datetimes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364646009
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df2 = df.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364646630
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df2.DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL = pd.to_datetime(\n",
+    "    df2.DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364648635
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# mainly nan\n",
+    "# df2.DISCHARGE_READY_DATE.sample(10)\n",
+    "df2.EXPECTED_DISCHARGE_DATE = pd.to_datetime(\n",
+    "    df2.EXPECTED_DISCHARGE_DATE, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364649728
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df2.FIRST_START_DATE_TIME_WARD_STAY = pd.to_datetime(\n",
+    "    df2.FIRST_START_DATE_TIME_WARD_STAY, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364651621
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df2.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL = pd.to_datetime(\n",
+    "    df2.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL, format=\"%Y-%m-%d %H:%M:%S.%f\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364659732
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df2.dtypes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "## Data ordering\n",
+    "\n",
+    "How is data ordered?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364674378
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# not ordered by local patient id\n",
+    "df2.LOCAL_PATIENT_IDENTIFIER.head(10)\n",
+    "\n",
+    "# nb. value_counts() shows repeat visits - could this be feature?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364699219
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# not ordered by start-date\n",
+    "df2.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364703141
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# not by end-date\n",
+    "df2.DISCHARGE_DATE_HOSPITAL_PROVIDER_SPELL.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364706155
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# not by cds\n",
+    "df2.cds_unique_identifier.sample(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "### Order by arrival date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364712638
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df3 = df2.sort_values(by=\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\").reset_index(\n",
+    "    drop=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364712896
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df3.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "### Missing data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364793792
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "sns.set(rc={\"figure.figsize\": (15, 8)})\n",
+    "sns.heatmap(df3.isnull(), cbar=False);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364811686
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df3.isnull().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364811990
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df3.IS_major.unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364812191
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df3.IS_major.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364814773
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Extract columns with 100% empty values\n",
+    "empty_cols = df3.isnull().sum() == df.shape[0]\n",
+    "empty_cols = empty_cols[empty_cols].index.array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364818187
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "for col in empty_cols:\n",
+    "    print(f\"{col} values: {df[col].unique()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364821732
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df4 = df3.drop(columns=empty_cols)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364822763
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df4[df4.stroke_ward_stay.notna()].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364823900
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df4.stroke_ward_stay.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "Question:\n",
+    "\n",
+    "1. When does the block of missing data end?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364827198
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df4.iloc[df4.presenting_complaint.first_valid_index()][\n",
+    "    [\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\", \"presenting_complaint\"]\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364828194
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df4.iloc[df4.presenting_complaint.first_valid_index() - 1][\n",
+    "    [\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\", \"presenting_complaint\"]\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "## Correlation plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364836652
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Pearson correlation by default:\n",
+    "corr = df4.corr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364837702
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "sns.set_theme(style=\"white\")\n",
+    "\n",
+    "# Generate a mask for the upper triangle\n",
+    "mask = np.triu(np.ones_like(corr, dtype=bool))\n",
+    "\n",
+    "# Set up the matplotlib figure\n",
+    "f, ax = plt.subplots(figsize=(15, 8))\n",
+    "\n",
+    "# Generate a custom diverging colormap\n",
+    "cmap = sns.diverging_palette(230, 20, as_cmap=True)\n",
+    "\n",
+    "\n",
+    "# Draw the heatmap with the mask and correct aspect ratio\n",
+    "sns.heatmap(\n",
+    "    corr,\n",
+    "    mask=mask,\n",
+    "    cmap=cmap,\n",
+    "    vmax=0.3,\n",
+    "    center=0,\n",
+    "    square=True,\n",
+    "    linewidths=0.5,\n",
+    "    cbar_kws={\"shrink\": 0.5},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364849249
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(df4.FIRST_WARD_STAY_IDENTIFIER.unique())\n",
+    "df4.FIRST_WARD_STAY_IDENTIFIER.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364869643
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Remove empty/single value columns\n",
+    "df5 = df4.drop(\n",
+    "    columns=[\n",
+    "        \"FIRST_WARD_STAY_IDENTIFIER\",\n",
+    "        \"LENGTH_OF_STAY_IN_MINUTES\",\n",
+    "        \"START_DATE_HOSPITAL_PROVIDER_SPELL\",\n",
+    "        \"EXPECTED_DISCHARGE_DATE_TIME\",\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364886392
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# How many negative/invalid LoS are there?\n",
+    "df5[df5.LENGTH_OF_STAY < 0].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364892662
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Remove invalid LoS\n",
+    "df6 = df5[df5.LENGTH_OF_STAY > -1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "## Check duplicate rows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364898062
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df6[df6.duplicated(keep=False)].sort_values(\n",
+    "    by=\"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\"\n",
+    ").head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364902644
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df7 = df6.drop_duplicates()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364902916
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(df6.shape)\n",
+    "print(df7.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "## Check duplicate columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364903100
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df7.FIRST_START_DATE_TIME_WARD_STAY.equals(df7.START_DATE_TIME_HOSPITAL_PROVIDER_SPELL)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364903316
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df7[\n",
+    "    [\"FIRST_START_DATE_TIME_WARD_STAY\", \"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\"]\n",
+    "].sample(100).diff(axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364903576
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df7.loc[154218]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364904756
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    df7[[\"FIRST_START_DATE_TIME_WARD_STAY\", \"START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\"]]\n",
+    "    .diff(axis=1)\n",
+    "    .START_DATE_TIME_HOSPITAL_PROVIDER_SPELL\n",
+    "    > pd.Timedelta(0)\n",
+    ").sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364921884
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Drop duplicate columns\n",
+    "df8 = df7.drop(columns=\"FIRST_START_DATE_TIME_WARD_STAY\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364922064
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df8.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "## Pandas profiling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364923945
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pd.__version__\n",
+    "# note bug with version 1.4.1: https://github.com/ydataai/pandas-profiling/issues/911\n",
+    "# use lower version (e.g. 1.3.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364933610
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Dataset large and crashing without minimal=True\n",
+    "profile = ProfileReport(df8, title=\"Pandas Profiling Report\", minimal=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364983208
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "profile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1646758800346
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df8.attendance_type.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650364983494
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Drop invalid/incomplete columns\n",
+    "df9 = df8.drop(\n",
+    "    columns=[\n",
+    "        \"FIRST_REGULAR_DAY_OR_NIGHT_ADMISSION_DESCRIPTION\",\n",
+    "        \"wait\",\n",
+    "        \"attendance_type\",\n",
+    "        \"initial_wait\",\n",
+    "        \"arrival_day_of_week\",\n",
+    "        \"arrival_month_name\",\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650365048840
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "sns.set(rc={\"figure.figsize\": (15, 8)})\n",
+    "sns.heatmap(df9.isnull(), cbar=False);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "source": [
+    "## Export snapshot data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "gather": {
+     "logged": 1650365053678
+    },
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df9.to_parquet(\"../data/02-eda.parquet\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "6d65a8c07f5b6469e0fc613f182488c0dccce05038bbda39e5ac9075c0454d11"
+  },
+  "kernel_info": {
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.1"
+  },
+  "microsoft": {
+   "host": {
+    "AzureML": {
+     "notebookHasBeenCompleted": true
+    }
+   }
+  },
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -3,3 +3,4 @@
 This directory contains notebooks associated with this project.
 
 1. [01 Data loading](01%20Data%20loading.ipynb) - load in the dataset used for this project
+2. [02 EDA](02%20EDA.ipynb) - initial Exploratory Data Analysis


### PR DESCRIPTION
# Summary

**What/Why**

Add a basic EDA notebook, which does include some data cleaning as part of EDA.

**Your approach**

Add a basic notebook which outputs a new parquet file for onward analysis.

Cleaning mid-EDA was necessary to be able to explore some of the features and minimise noise during Pandas profiling.

**What to review**

New notebook: 02 EDA.ipynb

# Checklists

<!--
These are DO-CONFIRM checklists; it CONFIRMs that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests MAY be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [X] code runs
- [X] [developments are ethical][data-ethics-framework]
- [X] developments are secure (no data or notebook output)
- [X] you have made proportionate checks that the code works correctly
- [X] [minimum usable documentation][agilemodeling] written in the `docs` folder

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
